### PR TITLE
giveback of changes needed to work with ZX Spectrum and Wilderland

### DIFF
--- a/z80emu.h
+++ b/z80emu.h
@@ -145,6 +145,10 @@ typedef struct Z80_STATE {
 
 } Z80_STATE;
 
+/* Initialize processor's register pointers */
+
+extern void     Z80ResetTable (Z80_STATE *state);
+
 /* Initialize processor's state to power-on default. */
 
 extern void     Z80Reset (Z80_STATE *state);

--- a/z80user.h
+++ b/z80user.h
@@ -127,15 +127,28 @@ extern "C" {
 
 #define Z80_WRITE_WORD_INTERRUPT(address, x)	Z80_WRITE_WORD((address), (x))
 
-#define Z80_INPUT_BYTE(port, x)                                         \
+typedef unsigned char byte;
+typedef unsigned short word;
+
+#define Z80_INPUT_BYTE(portHi, portLo, x)                               \
 {                                                                       \
+        /* word p = ((word)((byte)(portHi)))<<8 | (byte)(portLo); */    \
+        /* (x) = InZ80(p); */                                           \
         SystemCall((ZEXTEST *) context);				\
 }
 
-#define Z80_OUTPUT_BYTE(port, x)                                        \
+#define Z80_OUTPUT_BYTE(portHi, portLo, x)                              \
 {                                                                       \
         ((ZEXTEST *) context)->is_done = !0; 				\
         number_cycles = 0;                                              \
+        /* word p = ((word)((byte)(portHi)))<<8 | (byte)(portLo); */    \
+        /* OutZ80( p, (byte)(x) ); */                                   \
+}
+
+/* called on JP, JR, CALL, RST, or RET */
+#define Z80_JUMP(pc)                                                    \
+{                                                                       \
+        /* JumpZ80((word)pc); */                                        \
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
from Wilderland: https://github.com/efa/Wilderland

changed:
 - separated Z80ResetTable() from Z80Reset() to let restore pointers between executions without reset the Z80

added:
 - Z80_JUMP(pc) interface will be called on Z80 jumps/call/ret/rst

fixed:
 - I/O with 16 bit port addresses
 - 'case IN_A_N', was reversed
 - reduced the number of WARNINGs
